### PR TITLE
On-demand CV PDF generation with caching and metadata, plus Sanity query update

### DIFF
--- a/pdf/queries.js
+++ b/pdf/queries.js
@@ -1,6 +1,7 @@
 // pdf/queries.js
 export function getCVQuery(lang = "ca") {
   return `*[_type == "siteSettings"][0]{
+    _updatedAt,
     nom,
     foto,
     "fotoUrl": foto.asset->url,

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -90,7 +90,7 @@ const cvDownloadUrl = `/api/cv/${lang}`;
 
   <!-- BOTTOM: accions i footer -->
   <div class="mt-6 flex justify-center gap-4 text-xl">
-    <a href={cvDownloadUrl} target="_blank" download title="Descarregar CV" class="text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
+    <a href={cvDownloadUrl} target="_blank" rel="noopener noreferrer" title="Descarregar CV" class="text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
       <i class="fa-solid fa-file-arrow-down"></i>
     </a>
     {settings?.linkedinUrl && (

--- a/src/lib/cv-storage.ts
+++ b/src/lib/cv-storage.ts
@@ -5,6 +5,10 @@ const STORAGE_DIR = process.env.CV_STORAGE_DIR || path.join(process.cwd(), 'stor
 
 const ALLOWED_LANGS = new Set(['ca', 'es', 'en']);
 
+type CvMeta = {
+  sourceUpdatedAt: string | null;
+};
+
 export function isSupportedLang(lang: string) {
   return ALLOWED_LANGS.has(lang);
 }
@@ -19,6 +23,10 @@ export function getCvPublicUrl(lang: string) {
 
 function getCvFilePath(lang: string) {
   return path.join(STORAGE_DIR, getCvFilename(lang));
+}
+
+function getCvMetaPath(lang: string) {
+  return path.join(STORAGE_DIR, `cv-aitor-${lang}.meta.json`);
 }
 
 export async function saveCv(lang: string, pdfBuffer: Buffer) {
@@ -49,6 +57,36 @@ export async function readCv(lang: string) {
     return {
       filename: getCvFilename(lang),
       file,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function saveCvMeta(lang: string, meta: CvMeta) {
+  if (!isSupportedLang(lang)) {
+    throw new Error(`Idioma no soportado: ${lang}`);
+  }
+
+  await fs.mkdir(STORAGE_DIR, { recursive: true });
+  await fs.writeFile(getCvMetaPath(lang), JSON.stringify(meta), 'utf-8');
+}
+
+export async function readCvMeta(lang: string): Promise<CvMeta | null> {
+  if (!isSupportedLang(lang)) {
+    return null;
+  }
+
+  try {
+    const raw = await fs.readFile(getCvMetaPath(lang), 'utf-8');
+    const parsed = JSON.parse(raw) as CvMeta;
+
+    if (!Object.hasOwn(parsed, 'sourceUpdatedAt')) {
+      return null;
+    }
+
+    return {
+      sourceUpdatedAt: parsed.sourceUpdatedAt ?? null,
     };
   } catch {
     return null;

--- a/src/pages/api/cv/[lang].ts
+++ b/src/pages/api/cv/[lang].ts
@@ -1,31 +1,91 @@
 import type { APIRoute } from 'astro';
-import { readCv } from '../../../lib/cv-storage';
+import { chromium } from 'playwright';
+import imageUrlBuilder from '@sanity/image-url';
+import { getCVQuery } from '../../../../pdf/queries.js';
+import { client } from '../../../../pdf/sanity.js';
+import { cvTemplate } from '../../../../pdf/template.js';
+import {
+  getCvFilename,
+  isSupportedLang,
+  readCv,
+  readCvMeta,
+  saveCv,
+  saveCvMeta,
+} from '../../../lib/cv-storage';
+
+const builder = imageUrlBuilder(client);
+
+function getPhotoUrl(photo: unknown) {
+  if (!photo) {
+    return '';
+  }
+
+  return builder.image(photo).width(400).height(400).fit('crop').url();
+}
+
+async function generatePdfBuffer(data: Record<string, any>, lang: string): Promise<Buffer> {
+  const fotoUrl = getPhotoUrl(data.foto);
+  const html = cvTemplate(data, fotoUrl, lang);
+
+  const browser = await chromium.launch();
+
+  try {
+    const page = await browser.newPage();
+    await page.setContent(html, { waitUntil: 'networkidle' });
+
+    const pdfBuffer = await page.pdf({
+      format: 'A4',
+      printBackground: true,
+      margin: { top: '10mm', bottom: '10mm', left: '8mm', right: '8mm' },
+    });
+
+    return pdfBuffer as Buffer;
+  } finally {
+    await browser.close();
+  }
+}
+
+function buildPdfResponse(file: Buffer, filename: string) {
+  return new Response(file, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'Cache-Control': 'no-store',
+    },
+  });
+}
 
 export const GET: APIRoute = async ({ params }) => {
   const lang = params.lang;
 
-  if (!lang) {
-    return new Response(JSON.stringify({ error: 'Idioma requerido' }), {
+  if (!lang || !isSupportedLang(lang)) {
+    return new Response(JSON.stringify({ error: 'Idioma no soportado' }), {
       status: 400,
       headers: { 'Content-Type': 'application/json' },
     });
   }
 
-  const cv = await readCv(lang);
+  const data = await client.fetch<Record<string, any> | null>(getCVQuery(lang));
 
-  if (!cv) {
-    return new Response(JSON.stringify({ error: 'CV no encontrado para este idioma' }), {
+  if (!data) {
+    return new Response(JSON.stringify({ error: 'No hay datos del CV en Sanity' }), {
       status: 404,
       headers: { 'Content-Type': 'application/json' },
     });
   }
 
-  return new Response(cv.file, {
-    status: 200,
-    headers: {
-      'Content-Type': 'application/pdf',
-      'Content-Disposition': `attachment; filename="${cv.filename}"`,
-      'Cache-Control': 'no-store',
-    },
-  });
+  const sourceUpdatedAt = data._updatedAt ?? null;
+  const cachedCv = await readCv(lang);
+  const cachedMeta = await readCvMeta(lang);
+
+  if (cachedCv && cachedMeta?.sourceUpdatedAt === sourceUpdatedAt) {
+    return buildPdfResponse(cachedCv.file, cachedCv.filename);
+  }
+
+  const pdfBuffer = await generatePdfBuffer(data, lang);
+  const savedCv = await saveCv(lang, pdfBuffer);
+  await saveCvMeta(lang, { sourceUpdatedAt });
+
+  return buildPdfResponse(pdfBuffer, savedCv.filename || getCvFilename(lang));
 };


### PR DESCRIPTION
### Motivation
- Serve up-to-date CV PDFs generated from Sanity data and avoid regenerating when the source hasn't changed. 
- Persist metadata about the Sanity source to enable cache validation and improve performance. 
- Small UI hardening to avoid window-opener risks on external downloads.

### Description
- Updated Sanity query in `pdf/queries.js` to include `_updatedAt` so the API can detect source changes. 
- Reworked the CV API at `src/pages/api/cv/[lang].ts` to fetch CV data from Sanity, render HTML via the `cvTemplate`, generate a PDF with `playwright.chromium`, and return it with proper PDF headers. 
- Added caching logic that compares Sanity's `_updatedAt` with locally stored metadata and serves the stored file when unchanged. 
- Extended `src/lib/cv-storage.ts` with meta read/write functions (`saveCvMeta` / `readCvMeta`) and maintained existing `saveCv` / `readCv` helpers; added a small `CvMeta` type and language validation via `isSupportedLang`. 
- Added image URL building using `@sanity/image-url` to produce the photo used in the PDF. 
- Minor frontend change in `src/components/Sidebar.astro` to add `rel="noopener noreferrer"` to the CV download link for security.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc3d595aa083319821ed3480f74731)