### PR TITLE
Proxy Directus assets and fix blog category query

### DIFF
--- a/src/lib/directus-content.ts
+++ b/src/lib/directus-content.ts
@@ -37,7 +37,18 @@ function getRawAssetId(value: unknown): string {
   return ''
 }
 
-export function getDirectusAssetUrl(file: unknown): string {
+function getDirectusBaseUrl(): string {
+  const rawUrl = typeof import.meta.env.DIRECTUS_URL === 'string' ? import.meta.env.DIRECTUS_URL : ''
+  return rawUrl.replace(/\/+$/, '')
+}
+
+function getDirectusAssetProxyUrl(assetPath: string, search?: string): string {
+  const encodedPath = encodeURIComponent(assetPath.replace(/^\/+/, ''))
+  const query = search && search.trim() ? `?${search.replace(/^\?/, '')}` : ''
+  return `/api/directus-assets/${encodedPath}${query}`
+}
+
+export function getDirectusAssetOriginUrl(file: unknown): string {
   const rawId = getRawAssetId(file)
   if (!rawId) return ''
 
@@ -45,7 +56,24 @@ export function getDirectusAssetUrl(file: unknown): string {
     return rawId
   }
 
-  return `${import.meta.env.DIRECTUS_URL}/assets/${rawId}`
+  return `${getDirectusBaseUrl()}/assets/${rawId}`
+}
+
+export function getDirectusAssetUrl(file: unknown): string {
+  const rawId = getRawAssetId(file)
+  if (!rawId) return ''
+
+  if (rawId.startsWith('http://') || rawId.startsWith('https://')) {
+    try {
+      const parsed = new URL(rawId)
+      const assetPath = parsed.pathname.replace(/^\/+/, '')
+      return getDirectusAssetProxyUrl(assetPath, parsed.search)
+    } catch {
+      return rawId
+    }
+  }
+
+  return getDirectusAssetProxyUrl(`assets/${rawId}`)
 }
 
 function getLocalizedField(record: Record<string, unknown>, baseField: string, lang: SupportedLang): string {
@@ -371,7 +399,7 @@ export async function getCategories(lang: SupportedLang): Promise<Category[]> {
     ),
     directus.request(
       readItems('post', {
-        fields: ['categories.category.slug', 'categories.category_id.slug', 'categories.slug'],
+        fields: ['categories.category.slug', 'categories.category_id.slug'],
       }),
     ),
   ])

--- a/src/pages/api/cv/[lang].ts
+++ b/src/pages/api/cv/[lang].ts
@@ -9,10 +9,10 @@ import {
   saveCv,
   saveCvMeta,
 } from '../../../lib/cv-storage';
-import { getCvData, getDirectusAssetUrl, type SupportedLang } from '../../../lib/directus-content';
+import { getCvData, getDirectusAssetOriginUrl, type SupportedLang } from '../../../lib/directus-content';
 
 function getPhotoUrl(photo: unknown) {
-  const photoUrl = getDirectusAssetUrl(photo)
+  const photoUrl = getDirectusAssetOriginUrl(photo)
   if (!photoUrl) {
     return '';
   }

--- a/src/pages/api/directus-assets/[path].ts
+++ b/src/pages/api/directus-assets/[path].ts
@@ -1,0 +1,56 @@
+import type { APIRoute } from 'astro'
+
+function getDirectusBaseUrl(): string {
+  const rawUrl = typeof import.meta.env.DIRECTUS_URL === 'string' ? import.meta.env.DIRECTUS_URL : ''
+  return rawUrl.replace(/\/+$/, '')
+}
+
+export const GET: APIRoute = async ({ params, request }) => {
+  const encodedPath = params.path
+  if (!encodedPath) {
+    return new Response('Missing asset path', { status: 400 })
+  }
+
+  const decodedPath = decodeURIComponent(encodedPath).replace(/^\/+/, '')
+  if (!decodedPath.startsWith('assets/')) {
+    return new Response('Invalid asset path', { status: 400 })
+  }
+
+  const directusBaseUrl = getDirectusBaseUrl()
+  if (!directusBaseUrl) {
+    return new Response('Missing DIRECTUS_URL', { status: 500 })
+  }
+
+  const requestUrl = new URL(request.url)
+  const upstreamUrl = `${directusBaseUrl}/${decodedPath}${requestUrl.search}`
+
+  const token = typeof import.meta.env.DIRECTUS_TOKEN === 'string' ? import.meta.env.DIRECTUS_TOKEN : ''
+  const headers: HeadersInit = {}
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`
+  }
+
+  const upstreamResponse = await fetch(upstreamUrl, { headers })
+
+  if (!upstreamResponse.ok) {
+    return new Response(`Failed to fetch asset (${upstreamResponse.status})`, {
+      status: upstreamResponse.status,
+    })
+  }
+
+  const responseHeaders = new Headers()
+  const contentType = upstreamResponse.headers.get('content-type')
+  const cacheControl = upstreamResponse.headers.get('cache-control')
+
+  if (contentType) {
+    responseHeaders.set('Content-Type', contentType)
+  }
+
+  responseHeaders.set('Cache-Control', cacheControl || 'public, max-age=3600')
+
+  return new Response(upstreamResponse.body, {
+    status: upstreamResponse.status,
+    headers: responseHeaders,
+  })
+}

--- a/src/pages/api/generate-upload-cv.ts
+++ b/src/pages/api/generate-upload-cv.ts
@@ -2,10 +2,10 @@ import type { APIRoute } from 'astro';
 import { chromium } from 'playwright';
 import { cvTemplate } from '../../../pdf/template.js';
 import { saveCv } from '../../lib/cv-storage';
-import { getCvData, getDirectusAssetUrl, type SupportedLang } from '../../lib/directus-content';
+import { getCvData, getDirectusAssetOriginUrl, type SupportedLang } from '../../lib/directus-content';
 
 function getPhotoUrl(photo: unknown) {
-  const photoUrl = getDirectusAssetUrl(photo)
+  const photoUrl = getDirectusAssetOriginUrl(photo)
   if (!photoUrl) {
     return ''
   }


### PR DESCRIPTION
### Motivation
- Evitar que el navegador cargue recursos Directus directamente y provoque mixed-content o `ERR_CERT_AUTHORITY_INVALID` cuando la web se sirve por HTTPS. 
- Mantener la generación de PDFs server-side (Playwright) con URLs de Directus válidas desde el servidor. 
- Resolver el error al renderizar `/blog` causado por una consulta que pedía un campo relacional no permitido/ inexistente (`categories.slug`).

### Description
- Añadido un endpoint proxy `GET /api/directus-assets/:path` para servir los assets de Directus desde el servidor y adjuntar encabezados y cacheo apropiados (archivo `src/pages/api/directus-assets/[path].ts`).
- Modificada la lógica de assets en `src/lib/directus-content.ts` para normalizar la `DIRECTUS_URL`, generar URLs proxificadas con `getDirectusAssetUrl()` y exponer `getDirectusAssetOriginUrl()` para usos server-side.
- Actualizados los endpoints de generación de CV/PDF (`src/pages/api/generate-upload-cv.ts` y `src/pages/api/cv/[lang].ts`) para usar `getDirectusAssetOriginUrl()` en la renderización server-side.
- Corregida la consulta en `getCategories` para dejar de solicitar `categories.slug` desde la relación en `post` y así evitar el fallo de permisos/field inexistente.

### Testing
- Ejecutado `npm run build` en CI-like entorno; la build se inició pero falló con Rollup/Vite por no resolver la dependencia `@directus/sdk`, un problema de entorno/dependencias preexistente no introducido por estos cambios, por lo que la verificación de build completa no pudo terminar correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d77b5d96f48331822d17ae678adae7)