### PR TITLE
Replace Font Awesome with local SVG icons and add optional self-hosted analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,9 @@
 DIRECTUS_URL=https://your-directus-instance.example.com
 DIRECTUS_TOKEN=your_directus_static_token
+
+# Optional analytics (self-hosted compatible)
+# PUBLIC_ANALYTICS_PROVIDER=umami
+# PUBLIC_ANALYTICS_SRC=https://stats.your-domain.com/script.js
+# PUBLIC_ANALYTICS_WEBSITE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+# PUBLIC_ANALYTICS_DOMAIN=your-domain.com
+

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Este proyecto ya no depende de Vercel ni de `@vercel/blob`.
 
 - Build en modo servidor (`@astrojs/node` + `output: server`) para poder exponer API routes en el VPS.
 - Eliminadas integraciones de Vercel Analytics/Speed Insights.
+- Eliminada dependencia de Font Awesome (icons SVG locals).
 - Nueva generación y almacenamiento local de CV PDFs en el servidor.
 - Descarga del botón de CV conectada al endpoint local del servidor.
 
@@ -79,3 +80,33 @@ Aquest projecte necessita Directus:
 - `DIRECTUS_TOKEN`: token estàtic amb permisos de lectura
 
 Pots partir de `.env.example`.
+
+## Analítica de visites (opcional)
+
+Ara es pot injectar un script d’analítica sense dependre de llibreries externes.
+
+Variables disponibles:
+
+- `PUBLIC_ANALYTICS_PROVIDER`: `umami`, `plausible` o `custom`
+- `PUBLIC_ANALYTICS_SRC`: URL completa del script (pots apuntar al teu servidor)
+- `PUBLIC_ANALYTICS_WEBSITE_ID`: necessari en Umami
+- `PUBLIC_ANALYTICS_DOMAIN`: recomanat en Plausible
+
+### Exemple amb Umami autoallotjat
+
+```env
+PUBLIC_ANALYTICS_PROVIDER=umami
+PUBLIC_ANALYTICS_SRC=https://stats.example.com/script.js
+PUBLIC_ANALYTICS_WEBSITE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+```
+
+### Exemple amb Plausible autoallotjat
+
+```env
+PUBLIC_ANALYTICS_PROVIDER=plausible
+PUBLIC_ANALYTICS_SRC=https://analytics.example.com/js/script.js
+PUBLIC_ANALYTICS_DOMAIN=aitorivera.com
+```
+
+Si no defineixes aquestes variables, no es carrega cap script d’analítica.
+

--- a/src/components/Analytics.astro
+++ b/src/components/Analytics.astro
@@ -1,0 +1,26 @@
+---
+const analyticsProvider = import.meta.env.PUBLIC_ANALYTICS_PROVIDER;
+const analyticsSrc = import.meta.env.PUBLIC_ANALYTICS_SRC;
+const analyticsDomain = import.meta.env.PUBLIC_ANALYTICS_DOMAIN;
+const analyticsWebsiteId = import.meta.env.PUBLIC_ANALYTICS_WEBSITE_ID;
+
+const supportedProviders = ['umami', 'plausible', 'custom'];
+const isProviderSupported = supportedProviders.includes(analyticsProvider);
+
+const shouldLoadScript =
+  Boolean(analyticsProvider) &&
+  isProviderSupported &&
+  Boolean(analyticsSrc) &&
+  (analyticsProvider === 'custom' || Boolean(analyticsWebsiteId) || Boolean(analyticsDomain));
+---
+
+{
+  shouldLoadScript && (
+    <script
+      defer
+      data-website-id={analyticsWebsiteId}
+      data-domain={analyticsDomain}
+      src={analyticsSrc}
+    ></script>
+  )
+}

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -7,6 +7,7 @@ import ContactModal from './ContactModal.jsx';
 import ScrollAwareNav from './ScrollAwareNav.jsx';
 import HeroShrinkHeader from './HeroShrinkHeader.jsx';
 import { SunIcon, MoonIcon } from '@heroicons/react/24/solid';
+import AppIcon from './icons/AppIcon.astro';
 
 const { settings, t, lang } = Astro.props;
 const fotoUrl = settings?.fotoUrl || getDirectusAssetUrl(settings?.foto);
@@ -91,21 +92,21 @@ const cvDownloadUrl = `/api/cv/${lang}`;
   <!-- BOTTOM: accions i footer -->
   <div class="mt-6 flex justify-center gap-4 text-xl">
     <a href={cvDownloadUrl} target="_blank" rel="noopener noreferrer" title="Descarregar CV" class="text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
-      <i class="fa-solid fa-file-arrow-down"></i>
+      <AppIcon name="download" />
     </a>
     {settings?.linkedinUrl && (
       <a href={settings.linkedinUrl} aria-label={`LinkedIn de ${settings.nom}`} target="_blank" class="text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
-        <i class="fa-brands fa-linkedin"></i>
+        <AppIcon name="linkedin" />
       </a>
     )}
     {settings?.githubUrl && (
       <a href={settings.githubUrl} aria-label={`GitHub de ${settings.nom}`} target="_blank" class="text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors">
-        <i class="fa-brands fa-github"></i>
+        <AppIcon name="github" />
       </a>
     )}
     {settings?.email && (
       <a href={`mailto:${settings.email}`} aria-label={`Email de ${settings.nom}`} class="text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
-        <i class="fa-solid fa-envelope"></i>
+        <AppIcon name="email" />
       </a>
     )}
   </div>

--- a/src/components/blog/BlogSidebar.astro
+++ b/src/components/blog/BlogSidebar.astro
@@ -5,6 +5,7 @@ import { getRelativeLocaleUrl } from 'astro:i18n';
 import Footer from '../Footer.astro';
 import ContactModal from '../ContactModal.jsx';
 import { HomeIcon, SunIcon, MoonIcon, Bars3Icon } from '@heroicons/react/24/solid';
+import AppIcon from '../icons/AppIcon.astro';
 
 const { lang = 'ca', settings, blogTitle, blogDescription, categories = [], tags = [], recentPosts = [], t } = Astro.props;
 ---
@@ -101,13 +102,13 @@ const { lang = 'ca', settings, blogTitle, blogDescription, categories = [], tags
           <!-- Xarxes socials -->
           <div class="flex justify-center gap-4 text-lg mt-2">
             {settings?.linkedinUrl && (
-              <a href={settings.linkedinUrl} target="_blank" class="hover:text-indigo-500"><i class="fa-brands fa-linkedin"></i></a>
+              <a href={settings.linkedinUrl} target="_blank" class="hover:text-indigo-500"><AppIcon name="linkedin" /></a>
             )}
             {settings?.githubUrl && (
-              <a href={settings.githubUrl} target="_blank" class="hover:text-indigo-500"><i class="fa-brands fa-github"></i></a>
+              <a href={settings.githubUrl} target="_blank" class="hover:text-indigo-500"><AppIcon name="github" /></a>
             )}
             {settings?.email && (
-              <a href={`mailto:${settings.email}`} class="hover:text-indigo-500"><i class="fa-solid fa-envelope"></i></a>
+              <a href={`mailto:${settings.email}`} class="hover:text-indigo-500"><AppIcon name="email" /></a>
             )}
           </div>
         </div>
@@ -258,17 +259,17 @@ const { lang = 'ca', settings, blogTitle, blogDescription, categories = [], tags
   <div class="mt-3 lg:mt-6 flex justify-center gap-4 text-lg lg:text-xl">
     {settings?.linkedinUrl && (
       <a href={settings.linkedinUrl} aria-label={`LinkedIn de ${settings.nom}`} target="_blank" class="text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
-        <i class="fa-brands fa-linkedin"></i>
+        <AppIcon name="linkedin" />
       </a>
     )}
     {settings?.githubUrl && (
       <a href={settings.githubUrl} aria-label={`GitHub de ${settings.nom}`} target="_blank" class="text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors">
-        <i class="fa-brands fa-github"></i>
+        <AppIcon name="github" />
       </a>
     )}
     {settings?.email && (
       <a href={`mailto:${settings.email}`} aria-label={`Email de ${settings.nom}`} class="text-slate-500 dark:text-slate-400 hover:text-indigo-600 dark:hover:text-indigo-400 transition-colors">
-        <i class="fa-solid fa-envelope"></i>
+        <AppIcon name="email" />
       </a>
     )}
   </div>

--- a/src/components/icons/AppIcon.astro
+++ b/src/components/icons/AppIcon.astro
@@ -1,0 +1,43 @@
+---
+interface Props {
+  name: 'linkedin' | 'github' | 'email' | 'download';
+  class?: string;
+}
+
+const { name, class: className = 'w-5 h-5' } = Astro.props;
+---
+
+{
+  name === 'linkedin' && (
+    <svg viewBox="0 0 24 24" fill="currentColor" class={className} aria-hidden="true">
+      <path d="M4.98 3.5A2.5 2.5 0 1 0 5 8.5a2.5 2.5 0 0 0-.02-5ZM3 9h4v12H3V9Zm7 0h3.8v1.71h.05c.53-1 1.83-2.06 3.76-2.06 4.02 0 4.76 2.65 4.76 6.1V21h-4v-5.5c0-1.32-.03-3.02-1.84-3.02-1.85 0-2.14 1.44-2.14 2.93V21h-4V9Z" />
+    </svg>
+  )
+}
+
+{
+  name === 'github' && (
+    <svg viewBox="0 0 24 24" fill="currentColor" class={className} aria-hidden="true">
+      <path d="M12 2C6.48 2 2 6.58 2 12.23c0 4.52 2.87 8.35 6.84 9.71.5.1.68-.22.68-.49 0-.24-.01-.89-.01-1.74-2.78.62-3.37-1.37-3.37-1.37-.45-1.18-1.11-1.5-1.11-1.5-.91-.63.07-.62.07-.62 1 .07 1.53 1.05 1.53 1.05.9 1.57 2.36 1.12 2.93.86.09-.67.35-1.12.63-1.37-2.22-.26-4.56-1.14-4.56-5.05 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.3.1-2.71 0 0 .84-.28 2.75 1.05A9.35 9.35 0 0 1 12 6.84c.85 0 1.7.12 2.5.35 1.9-1.33 2.74-1.05 2.74-1.05.55 1.4.21 2.45.1 2.7.64.73 1.03 1.64 1.03 2.76 0 3.92-2.34 4.78-4.58 5.03.36.32.68.95.68 1.93 0 1.39-.01 2.52-.01 2.86 0 .27.18.59.69.49A10.25 10.25 0 0 0 22 12.23C22 6.58 17.52 2 12 2Z" />
+    </svg>
+  )
+}
+
+{
+  name === 'email' && (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class={className} aria-hidden="true">
+      <rect x="3" y="5" width="18" height="14" rx="2" />
+      <path d="m4 7 8 6 8-6" />
+    </svg>
+  )
+}
+
+{
+  name === 'download' && (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" class={className} aria-hidden="true">
+      <path d="M12 3v11" />
+      <path d="m7.5 9.5 4.5 4.5 4.5-4.5" />
+      <path d="M4 20h16" />
+    </svg>
+  )
+}

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -3,6 +3,10 @@
 interface ImportMetaEnv {
   readonly DIRECTUS_URL: string
   readonly DIRECTUS_TOKEN: string
+  readonly PUBLIC_ANALYTICS_PROVIDER?: 'umami' | 'plausible' | 'custom'
+  readonly PUBLIC_ANALYTICS_SRC?: string
+  readonly PUBLIC_ANALYTICS_WEBSITE_ID?: string
+  readonly PUBLIC_ANALYTICS_DOMAIN?: string
 }
 
 interface ImportMeta {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -5,6 +5,7 @@ import { ClientRouter  } from 'astro:transitions';
 import themeScript from '../scripts/theme.js?raw';
 import { SEO } from 'astro-seo';
 import BackToTop from '../components/BackToTop.jsx';
+import Analytics from '../components/Analytics.astro';
 
 
 interface Props {
@@ -60,8 +61,8 @@ const {
     <link rel="sitemap" href="/sitemap-index.xml" />
     <meta name="viewport" content="width=device-width" />
 
-    <script src="https://kit.fontawesome.com/4933c02f67.js" crossorigin="anonymous" defer></script>
     <ClientRouter />
+    <Analytics />
   </head>
   <body class="font-sans bg-slate-100 dark:bg-slate-900 text-slate-800 dark:text-slate-300 transition-colors duration-300">
     <slot />


### PR DESCRIPTION
### Motivation

- Remove dependency on external icon CDNs to make the site self-contained and easier to host on a personal VPS. 
- Provide a lightweight, opt-in analytics hook that can load self-hosted providers (Umami/Plausible) or a custom script. 
- Keep the UI identical while avoiding external network requests for icons and analytics by default. 

### Description

- Removed the Font Awesome kit `<script>` from the global layout and integrated a new `Analytics` component into `src/layouts/Layout.astro`. 
- Added a reusable local SVG icon component `src/components/icons/AppIcon.astro` that supports `linkedin`, `github`, `email`, and `download`. 
- Replaced Font Awesome usages in both sidebars with `<AppIcon />` calls in `src/components/Sidebar.astro` and `src/components/blog/BlogSidebar.astro`. 
- Added `src/components/Analytics.astro`, extended `src/env.d.ts` with public analytics env typings, updated `.env.example` and `README.md` with configuration and examples. 

### Testing

- Ran `npm install` to update dependencies and ensure dev packages are resolved, which completed successfully. 
- Built the project with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d78c13aaac83319c164ff24e334b9b)