### PR TITLE
Improve local font caching and add `font-display: swap` for Space Grotesk

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,14 @@
+import type { MiddlewareHandler } from 'astro';
+
+const ONE_YEAR_IN_SECONDS = 60 * 60 * 24 * 365;
+
+export const onRequest: MiddlewareHandler = async (context, next) => {
+  const response = await next();
+  const pathname = context.url.pathname;
+
+  if (pathname.startsWith('/fonts/')) {
+    response.headers.set('Cache-Control', `public, max-age=${ONE_YEAR_IN_SECONDS}, immutable`);
+  }
+
+  return response;
+};

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -12,6 +12,7 @@
   font-weight: 300 700; 
   font-optical-sizing: auto;
   font-style: normal;
+  font-display: swap;
 }
 
 html.theme-transition {


### PR DESCRIPTION
### Motivation
- Fix Lighthouse warnings about inefficient cache lifetimes for the local font file and suboptimal font rendering behavior.
- Ensure local font assets under `/fonts/*` are served with long-lived cache headers to reduce transfer size on repeat visits.

### Description
- Added `src/middleware.ts` Astro middleware that sets `Cache-Control: public, max-age=31536000, immutable` for requests starting with `/fonts/`.
- Updated `@font-face` in `src/styles/global.css` to include `font-display: swap` for the `Space Grotesk` font to improve text rendering behavior.

### Testing
- Ran `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a89e23b083319eb77e29d0c7ad7c)