### PR TITLE
fix: correct apostrophe syntax errors in blog index templates

### DIFF
--- a/src/pages/[locale]/blog/index.astro
+++ b/src/pages/[locale]/blog/index.astro
@@ -34,7 +34,7 @@ const hreflangUrls = [
 ---
 
 <Layout
-  title={settings?.title || ‘Blog d\’Aitor Rivera’}
+  title={settings?.title || "Blog d’Aitor Rivera"}
   description={settings?.description || ‘Articles sobre desenvolupament, gestió i experiències personals.’}
   lang={lang}
   canonical={`${siteUrl}/${lang === ‘ca’ ? ‘’ : `${lang}/`}blog`}
@@ -43,8 +43,8 @@ const hreflangUrls = [
     <BlogSidebar
       lang={lang}
       settings={sidebarSettings}
-      blogTitle={settings?.title || 'Blog d’Aitor Rivera'}
-      blogDescription={settings?.description || 'Articles sobre desenvolupament, gestió i experiències personals.'}
+      blogTitle={settings?.title || "Blog d’Aitor Rivera"}
+      blogDescription={settings?.description || ‘Articles sobre desenvolupament, gestió i experiències personals.’}
       categories={categories}
       tags={tags}
       recentPosts={recentPosts}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -27,7 +27,7 @@ const hreflangUrls = [
 ---
 
 <Layout
-  title={settings?.title || ‘Blog d\’Aitor Rivera’}
+  title={settings?.title || "Blog d’Aitor Rivera"}
   description={settings?.description || ‘Articles sobre desenvolupament, gestió i experiències personals.’}
   lang={lang}
   canonical={`${siteUrl}/${lang === ‘ca’ ? ‘’ : `${lang}/`}blog`}
@@ -37,8 +37,8 @@ const hreflangUrls = [
     <BlogSidebar
       lang={lang}
       settings={sidebarSettings}
-      blogTitle={settings?.title || 'Blog d’Aitor Rivera'}
-      blogDescription={settings?.description || 'Articles sobre desenvolupament, gestió i experiències personals.'}
+      blogTitle={settings?.title || "Blog d’Aitor Rivera"}
+      blogDescription={settings?.description || ‘Articles sobre desenvolupament, gestió i experiències personals.’}
       categories={categories}
       tags={tags}
       recentPosts={recentPosts}


### PR DESCRIPTION
\'  is not a valid JSX escape inside attribute expressions — Astro/esbuild rejects it with "Unexpected '\''" at build time.
Also fixed an unescaped apostrophe in the blogTitle fallback prop. Changed both occurrences to double-quoted strings: "Blog d'Aitor Rivera".

Fixes broken Docker build (exit code 1 at `npm run build`).

https://claude.ai/code/session_01YYr3MsBp1WzqMFjE3vziiJ