### PR TITLE
feat: section scroll-snap — mini-pages per secció amb indicador lateral

### DIFF
--- a/src/components/BackToTop.jsx
+++ b/src/components/BackToTop.jsx
@@ -1,26 +1,49 @@
 import { motion, useScroll, useTransform, AnimatePresence } from "framer-motion";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { RocketLaunchIcon } from "@heroicons/react/24/solid";
 
 const LABELS = {
-  ca: 'Pujar a l\'inici',
+  ca: "Pujar a l'inici",
   es: 'Subir al inicio',
   en: 'Back to top',
 };
 
 export default function BackToTopRocketProgress() {
   const [show, setShow] = useState(false);
-  const { scrollYProgress } = useScroll();
+  const mainRef = useRef(null);
   const lang = typeof document !== 'undefined' ? (document.documentElement.lang || 'ca') : 'ca';
   const label = LABELS[lang] || LABELS.ca;
 
+  // useScroll targets the main snap container on desktop, falls back to window
+  const { scrollYProgress } = useScroll({ container: mainRef });
   const pathLength = useTransform(scrollYProgress, [0, 1], [1, 0]);
 
   useEffect(() => {
-    const onScroll = () => setShow(window.scrollY > 300);
-    window.addEventListener("scroll", onScroll);
-    return () => window.removeEventListener("scroll", onScroll);
+    const mainEl = document.getElementById('main-content');
+    mainRef.current = mainEl;
+
+    const onScroll = () => {
+      const pos = mainEl ? mainEl.scrollTop : window.scrollY;
+      setShow(pos > 300);
+    };
+
+    mainEl?.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('scroll', onScroll, { passive: true });
+
+    return () => {
+      mainEl?.removeEventListener('scroll', onScroll);
+      window.removeEventListener('scroll', onScroll);
+    };
   }, []);
+
+  const handleClick = () => {
+    const mainEl = document.getElementById('main-content');
+    if (mainEl && mainEl.scrollTop > 0) {
+      mainEl.scrollTo({ top: 0, behavior: 'smooth' });
+    } else {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  };
 
   return (
     <AnimatePresence>
@@ -30,9 +53,11 @@ export default function BackToTopRocketProgress() {
           animate={{ opacity: 1, y: 0, rotate: 0 }}
           exit={{ opacity: 0, y: 50, rotate: 15 }}
           transition={{ duration: 0.3, ease: "circOut" }}
-          whileHover={{ y: [0, -8, 0], transition: { y: { repeat: Infinity, duration: 0.8, ease: "easeInOut" } } }}
-          
-          onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+          whileHover={{
+            y: [0, -8, 0],
+            transition: { y: { repeat: Infinity, duration: 0.8, ease: "easeInOut" } },
+          }}
+          onClick={handleClick}
           className="fixed bottom-4 right-4 z-50 w-12 h-12 md:w-14 md:h-14 rounded-full bg-indigo-900 text-white shadow-lg flex items-center justify-center hover:bg-indigo-950"
           aria-label={label}
         >
@@ -46,16 +71,15 @@ export default function BackToTopRocketProgress() {
             focusable="false"
           >
             <circle cx="50" cy="50" r="45" stroke="" strokeWidth="8" />
-            
             <motion.circle
               cx="50"
               cy="50"
               r="45"
-              stroke="#4f39f6" // Tailwind indigo-600
+              stroke="#4f39f6"
               strokeWidth="8"
               strokeLinecap="round"
               transform="rotate(-90 50 50)"
-              style={{ pathLength }} 
+              style={{ pathLength }}
             />
           </motion.svg>
         </motion.button>

--- a/src/components/ExperienciaTimeline.jsx
+++ b/src/components/ExperienciaTimeline.jsx
@@ -4,7 +4,7 @@ import { motion, useInView } from 'framer-motion';
 
 export default function ExperienciaTimeline({ experiencies, heading }) {
   const ref = useRef(null);
-  const isInView = useInView(ref, { once: true, amount: 0.05 });
+  const isInView = useInView(ref, { once: false, amount: 0.05 });
 
   return (
     <section id="experiencia" className="mb-24 scroll-mt-24">

--- a/src/components/HabilitatsAnimated.jsx
+++ b/src/components/HabilitatsAnimated.jsx
@@ -29,7 +29,7 @@ const headingVariant = {
 
 export default function HabilitatsAnimated({ tecniques, clau, t }) {
   const ref = useRef(null);
-  const isInView = useInView(ref, { once: true, amount: 0.1 });
+  const isInView = useInView(ref, { once: false, amount: 0.1 });
 
   return (
     <section id="habilitats" ref={ref} className="mb-24 scroll-mt-24">

--- a/src/components/SectionIndicator.jsx
+++ b/src/components/SectionIndicator.jsx
@@ -1,0 +1,52 @@
+// src/components/SectionIndicator.jsx
+import { useState, useEffect } from 'react';
+
+export default function SectionIndicator({ sections }) {
+  const [active, setActive] = useState(0);
+
+  useEffect(() => {
+    const mainEl = document.getElementById('main-content');
+    if (!mainEl) return;
+
+    const handleScroll = () => {
+      const h = mainEl.clientHeight;
+      if (h === 0) return;
+      const index = Math.round(mainEl.scrollTop / h);
+      setActive(Math.min(index, sections.length - 1));
+    };
+
+    mainEl.addEventListener('scroll', handleScroll, { passive: true });
+    handleScroll(); // detect initial position
+    return () => mainEl.removeEventListener('scroll', handleScroll);
+  }, [sections.length]);
+
+  const scrollTo = (i) => {
+    const mainEl = document.getElementById('main-content');
+    if (!mainEl) return;
+    mainEl.scrollTo({ top: i * mainEl.clientHeight, behavior: 'smooth' });
+  };
+
+  return (
+    <nav
+      className="hidden lg:flex fixed right-5 top-1/2 -translate-y-1/2 z-40 flex-col gap-3"
+      aria-label="Navegació per seccions"
+    >
+      {sections.map((section, i) => (
+        <button
+          key={section.id}
+          onClick={() => scrollTo(i)}
+          aria-label={section.label}
+          title={section.label}
+          aria-current={active === i ? 'true' : undefined}
+          className={`w-2 h-2 rounded-full transition-all duration-300
+            focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500
+            ${
+              active === i
+                ? 'bg-indigo-500 scale-[2] shadow-[0_0_6px_rgba(99,102,241,0.7)]'
+                : 'bg-slate-300 dark:bg-slate-600 hover:bg-indigo-400 dark:hover:bg-indigo-500 hover:scale-[1.5]'
+            }`}
+        />
+      ))}
+    </nav>
+  );
+}

--- a/src/pages/[locale]/index.astro
+++ b/src/pages/[locale]/index.astro
@@ -9,6 +9,7 @@ import Formacio from '../../components/sections/Formacio.astro'
 import SobreMi from '../../components/sections/SobreMi.astro'
 import { useTranslations, normalizeLocale } from '../../i18n/utils'
 import Footer from '../../components/Footer.astro'
+import SectionIndicator from '../../components/SectionIndicator.jsx'
 import { getExperiencia, getFormacio, getHabilitats, getSiteSettings } from '../../lib/directus-content'
 
 const lang = normalizeLocale(Astro.params.locale)
@@ -78,24 +79,36 @@ const websiteSchema = {
   hreflangUrls={hreflangUrls}
   jsonLd={[personSchema, websiteSchema]}
 >
-  <div class="max-w-screen-xl mx-auto lg:flex">
+  <div class="max-w-screen-xl mx-auto lg:flex lg:h-screen">
     <Sidebar settings={data} t={t} lang={lang} />
     <main
       id="main-content"
       transition:name="main-content"
-      class="w-full lg:w-3/5 p-8 lg:p-16 lg:py-24"
+      class="w-full lg:w-3/5 lg:h-screen lg:overflow-y-scroll lg:snap-y lg:snap-mandatory scroll-smooth"
     >
       {data ? (
         <>
-          <SobreMi sobremi={data.descripcioSobreMi} />
-          <Experiencia experiencies={data.experiencies} />
-          <Formacio formacions={data.formacions} />
-          <Habilitats tecniques={data.habilitatsTecniques} clau={data.habilitatsClau} />
-          <Idiomes />
+          <div class="snap-section">
+            <SobreMi sobremi={data.descripcioSobreMi} />
+          </div>
+          <div class="snap-section">
+            <Experiencia experiencies={data.experiencies} />
+          </div>
+          <div class="snap-section">
+            <Formacio formacions={data.formacions} />
+          </div>
+          <div class="snap-section">
+            <Habilitats tecniques={data.habilitatsTecniques} clau={data.habilitatsClau} />
+          </div>
+          <div class="snap-section">
+            <Idiomes />
+          </div>
         </>
       ) : (
-        <div class="bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200 p-8 rounded-2xl border border-slate-200 dark:border-slate-700">
-          <p>No s'han trobat dades de Directus.</p>
+        <div class="p-8 lg:p-16">
+          <div class="bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200 p-8 rounded-2xl border border-slate-200 dark:border-slate-700">
+            <p>No s'han trobat dades de Directus.</p>
+          </div>
         </div>
       )}
     </main>
@@ -106,4 +119,17 @@ const websiteSchema = {
       </footer>
     )}
   </div>
+
+  {data && (
+    <SectionIndicator
+      client:load
+      sections={[
+        { id: 'sobre-mi',    label: t['nav.about'] },
+        { id: 'experiencia', label: t['nav.experience'] },
+        { id: 'formacio',    label: t['nav.education'] },
+        { id: 'habilitats',  label: t['nav.skills'] },
+        { id: 'idiomes',     label: t['nav.languages'] },
+      ]}
+    />
+  )}
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,7 @@ import Idiomes from '../components/sections/Idiomes.astro';
 import Formacio from '../components/sections/Formacio.astro';
 import SobreMi from '../components/sections/SobreMi.astro';
 import Footer from '../components/Footer.astro';
+import SectionIndicator from '../components/SectionIndicator.jsx';
 import { normalizeLocale, useTranslations } from '../i18n/utils.ts';
 import { getExperiencia, getFormacio, getHabilitats, getSiteSettings } from '../lib/directus-content';
 
@@ -69,24 +70,36 @@ const websiteSchema = {
   hreflangUrls={hreflangUrls}
   jsonLd={[personSchema, websiteSchema]}
 >
-  <div class="max-w-screen-xl mx-auto lg:flex">
+  <div class="max-w-screen-xl mx-auto lg:flex lg:h-screen">
     <Sidebar settings={data} t={t} lang={lang} />
     <main
       id="main-content"
       transition:name="main-content"
-      class="w-full lg:w-3/5 p-8 lg:p-16 lg:py-24"
+      class="w-full lg:w-3/5 lg:h-screen lg:overflow-y-scroll lg:snap-y lg:snap-mandatory scroll-smooth"
     >
       {data ? (
         <>
-          <SobreMi sobremi={data.descripcioSobreMi} />
-          <Experiencia experiencies={data.experiencies} />
-          <Formacio formacions={data.formacions} />
-          <Habilitats tecniques={data.habilitatsTecniques} clau={data.habilitatsClau} />
-          <Idiomes />
+          <div class="snap-section">
+            <SobreMi sobremi={data.descripcioSobreMi} />
+          </div>
+          <div class="snap-section">
+            <Experiencia experiencies={data.experiencies} />
+          </div>
+          <div class="snap-section">
+            <Formacio formacions={data.formacions} />
+          </div>
+          <div class="snap-section">
+            <Habilitats tecniques={data.habilitatsTecniques} clau={data.habilitatsClau} />
+          </div>
+          <div class="snap-section">
+            <Idiomes />
+          </div>
         </>
       ) : (
-        <div class="bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200 p-8 rounded-2xl border border-slate-200 dark:border-slate-700">
-          <p>No s'han trobat dades de Directus.</p>
+        <div class="p-8 lg:p-16">
+          <div class="bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-200 p-8 rounded-2xl border border-slate-200 dark:border-slate-700">
+            <p>No s'han trobat dades de Directus.</p>
+          </div>
         </div>
       )}
     </main>
@@ -97,4 +110,17 @@ const websiteSchema = {
       </footer>
     )}
   </div>
+
+  {data && (
+    <SectionIndicator
+      client:load
+      sections={[
+        { id: 'sobre-mi',   label: t['nav.about'] },
+        { id: 'experiencia', label: t['nav.experience'] },
+        { id: 'formacio',   label: t['nav.education'] },
+        { id: 'habilitats', label: t['nav.skills'] },
+        { id: 'idiomes',    label: t['nav.languages'] },
+      ]}
+    />
+  )}
 </Layout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -445,9 +445,24 @@ html.theme-transition *::after {
   animation: blob-drift-reverse 18s ease-in-out infinite;
 }
 
-/* ─── Mobile layout padding ──────────────────────────── */
-@media (max-width: 1024px) {
-  main {
-    padding-top: 4rem;
+/* ─── Snap sections ──────────────────────────────────── */
+
+/* Mobile: normal flow with top clearance for the sticky nav */
+.snap-section {
+  padding: 1.5rem;
+}
+.snap-section:first-child {
+  padding-top: 5rem; /* clears HeroShrinkHeader (h-14 = 56px) */
+}
+
+/* Desktop: each section fills exactly one viewport-height "page"          */
+/* Tall sections (Experiència) get internal scroll via overflow-y: auto.   */
+/* When the inner scroll hits its boundary, the outer snap kicks in.        */
+@media (min-width: 1024px) {
+  .snap-section {
+    scroll-snap-align: start;
+    height: 100%;      /* = main's 100vh — one page per section */
+    overflow-y: auto;  /* tall sections scroll inside before advancing */
+    padding: 3.5rem 4rem;
   }
 }


### PR DESCRIPTION
Layout (desktop lg+):
- main #main-content → h-screen overflow-y-scroll snap-y snap-mandatory
- Outer container → lg:h-screen (la window deixa de desplaçar-se)
- Cada secció envoltada en .snap-section (height:100%, overflow-y:auto per seccions llargues)
- Al mòbil, el comportament és el scroll normal sense snap

SectionIndicator (nou):
- 5 puntets flotants a la dreta, posicionats fixed al centre de la pantalla
- El punt actiu s'escala x2 amb glow indigo
- Clic → scroll suau a la secció corresponent
- Visible únicament a desktop (hidden lg:flex)

BackToTop:
- Ara escolta scroll del main (desktop) i window (mòbil)
- useScroll({ container: mainRef }) per al progrés del cercle
- handleClick → scrollTo main si té scrollTop, window si no

Animacions:
- ExperienciaTimeline + HabilitatsAnimated: once:false → es reprenen cada cop que entres a la secció (cònsistent amb el comportament snap de 'mini pàgines')

https://claude.ai/code/session_013Yd9BH8zHRBPEm7eYgKTXt