### PR TITLE
fix: amaga scrollbars snap, centra contingut curt, dots més subtils

### DIFF
--- a/src/components/SectionIndicator.jsx
+++ b/src/components/SectionIndicator.jsx
@@ -28,7 +28,7 @@ export default function SectionIndicator({ sections }) {
 
   return (
     <nav
-      className="hidden lg:flex fixed right-5 top-1/2 -translate-y-1/2 z-40 flex-col gap-3"
+      className="hidden lg:flex fixed right-4 top-1/2 -translate-y-1/2 z-40 flex-col gap-2.5"
       aria-label="Navegació per seccions"
     >
       {sections.map((section, i) => (
@@ -38,12 +38,12 @@ export default function SectionIndicator({ sections }) {
           aria-label={section.label}
           title={section.label}
           aria-current={active === i ? 'true' : undefined}
-          className={`w-2 h-2 rounded-full transition-all duration-300
+          className={`w-1.5 h-1.5 rounded-full transition-all duration-300
             focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500
             ${
               active === i
-                ? 'bg-indigo-500 scale-[2] shadow-[0_0_6px_rgba(99,102,241,0.7)]'
-                : 'bg-slate-300 dark:bg-slate-600 hover:bg-indigo-400 dark:hover:bg-indigo-500 hover:scale-[1.5]'
+                ? 'bg-indigo-500 scale-[2.2] shadow-[0_0_5px_rgba(99,102,241,0.6)]'
+                : 'bg-slate-300/70 dark:bg-slate-600/70 hover:bg-indigo-400/80 hover:scale-[1.4]'
             }`}
         />
       ))}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -452,17 +452,36 @@ html.theme-transition *::after {
   padding: 1.5rem;
 }
 .snap-section:first-child {
-  padding-top: 5rem; /* clears HeroShrinkHeader (h-14 = 56px) */
+  padding-top: 5rem;
 }
 
-/* Desktop: each section fills exactly one viewport-height "page"          */
-/* Tall sections (Experiència) get internal scroll via overflow-y: auto.   */
-/* When the inner scroll hits its boundary, the outer snap kicks in.        */
+/* Desktop: each section fills exactly one viewport-height "page" */
 @media (min-width: 1024px) {
   .snap-section {
     scroll-snap-align: start;
-    height: 100%;      /* = main's 100vh — one page per section */
-    overflow-y: auto;  /* tall sections scroll inside before advancing */
+    height: 100%;
+    overflow-y: auto;
     padding: 3.5rem 4rem;
+
+    /* Vertically center short content; fall back to flex-start if content overflows */
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;   /* safe fallback */
+    justify-content: safe center;  /* modern browsers */
   }
+
+  /* Remove mb-24 spacers — snap sections are their own pages */
+  .snap-section section[id] {
+    margin-bottom: 0;
+  }
+}
+
+/* ─── Hide snap scrollbars (keep scroll functionality) ── */
+#main-content,
+.snap-section {
+  scrollbar-width: none; /* Firefox */
+}
+#main-content::-webkit-scrollbar,
+.snap-section::-webkit-scrollbar {
+  display: none; /* Chrome / Safari / Edge */
 }


### PR DESCRIPTION
- Hide scrollbars: #main-content i .snap-section amb scrollbar-width:none + ::-webkit-scrollbar:none
- Center content: justify-content: safe center per a seccions curtes (Formació, Idiomes, etc.); fallback flex-start si desborda
- Remove mb-24 dins snap sections via .snap-section section[id] { margin-bottom:0 }
- SectionIndicator: dots de w-2→w-1.5, gap-3→gap-2.5, inactive amb opacity 70%, right-5→right-4

https://claude.ai/code/session_013Yd9BH8zHRBPEm7eYgKTXt